### PR TITLE
use same Wikidata.php entry point as currently used

### DIFF
--- a/build_config/Wikidata_master/build_resources/Wikidata.php
+++ b/build_config/Wikidata_master/build_resources/Wikidata.php
@@ -1,3 +1,47 @@
 <?php
 
-include_once( __DIR__ . '/vendor/autoload.php' );
+if ( !defined( 'MEDIAWIKI' ) ) {
+	die( 'Not an entry point.' );
+}
+
+// Jenkins stuff part1
+if ( PHP_SAPI === 'cli' && getenv( 'JOB_NAME' ) === 'mwext-Wikidata-testextensions-master') {
+	// in future, run as non-experimental
+	if ( !defined( 'WB_EXPERIMENTAL_FEATURES' ) || !WB_EXPERIMENTAL_FEATURES ) {
+		define( 'WB_EXPERIMENTAL_FEATURES', true );
+	}
+
+	$wmgUseWikibaseRepo = true;
+	$wmgUseWikibaseClient = true;
+}
+
+// no magic, use wmf configs instead to control which entry points to load
+$wgEnableWikibaseRepo = false;
+$wgEnableWikibaseClient = false;
+
+include_once __DIR__ . '/vendor/autoload.php';
+
+if ( $wmgUseWikibaseRepo ) {
+	include_once( __DIR__ . '/extensions/Wikibase/repo/Wikibase.php' );
+}
+
+if ( $wmgUseWikibaseClient ) {
+	include_once( __DIR__ . '/extensions/Wikibase/client/WikibaseClient.php' );
+}
+
+$wgExtensionCredits['wikibase'][] = array(
+	'path' => __DIR__,
+	'name' => 'Wikidata Build',
+	'author' => array(
+		'The Wikidata team', // TODO: link?
+	),
+	'url' => 'https://www.mediawiki.org/wiki/Wikidata_build',
+	'description' => 'Wikidata extensions build'
+);
+
+// Jenkins stuff part2
+if( PHP_SAPI === 'cli' && getenv( 'JOB_NAME' ) === 'mwext-Wikidata-testextensions-master') {
+	//Jenkins always loads both so no need to check if they are loaded before getting settings
+	require_once __DIR__ . '/extensions/Wikibase/repo/ExampleSettings.php';
+	require_once __DIR__ . '/extensions/Wikibase/client/ExampleSettings.php';
+}


### PR DESCRIPTION
this ensures only client and/or repo are enabled,
per wmf config (as used on beta)

w/o this, we get a fatal error on clients
