### PR TITLE
Fix extension name for Special:Version

### DIFF
--- a/build_config/Wikidata_master/build_resources/Wikidata.php
+++ b/build_config/Wikidata_master/build_resources/Wikidata.php
@@ -31,7 +31,7 @@ if ( $wmgUseWikibaseClient ) {
 
 $wgExtensionCredits['wikibase'][] = array(
 	'path' => __DIR__,
-	'name' => 'Wikidata Build',
+	'name' => 'Wikidata',
 	'author' => array(
 		'The Wikidata team', // TODO: link?
 	),


### PR DESCRIPTION
have it match the gerrit repo name so that the
correct git hash is displayed.
