### PR TITLE
Use "prepend-autoloader": false

### DIFF
--- a/build_config/Wikidata_master/build_resources/composer.json
+++ b/build_config/Wikidata_master/build_resources/composer.json
@@ -28,6 +28,7 @@
     "config": {
         "github-oauth":{
             "github.com":"845d568f46a682fbf7fc5f92ed9397fc4ebdc072"
-        }
+        },
+        "prepend-autoloader": false
     }
 }


### PR DESCRIPTION
Composer's autoloader is slow, taking about 63µs per class, whereas MediaWiki's is fast, taking about 7µs per class. This adds up to an overhead of about 13% of CPU time on short requests such as API calls. On those same short requests, MediaWiki's autoloader finds most of the classes. So it makes sense to run it first, before the two Composer autoloaders. So change the config so that composer passes $prepend=false to spl_autoload_register().

Untested. But I tested this and it seemed to work: https://gerrit.wikimedia.org/r/#/c/176888/
